### PR TITLE
fix(types): import JSX to support React 19 / fix animated.div type er…

### DIFF
--- a/packages/animated/src/withAnimated.tsx
+++ b/packages/animated/src/withAnimated.tsx
@@ -66,7 +66,7 @@ export const withAnimated = (Component: any, host: HostConfig) => {
 
     const observer = new PropsObserver(callback, deps)
 
-    const observerRef = useRef<PropsObserver>(null)
+    const observerRef = useRef<PropsObserver | null>(null)
     useIsomorphicLayoutEffect(() => {
       observerRef.current = observer
 

--- a/packages/core/src/hooks/useSpring.test.tsx
+++ b/packages/core/src/hooks/useSpring.test.tsx
@@ -139,7 +139,7 @@ function createUpdater(Component: React.ComponentType<{ args: [any, any?] }>) {
     }
   })
 
-  function renderWithContext(elem: JSX.Element) {
+  function renderWithContext(elem: React.JSX.Element) {
     const wrapped = (
       <SpringContextProvider {...context}>{elem}</SpringContextProvider>
     )

--- a/packages/core/src/types/transition.ts
+++ b/packages/core/src/types/transition.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, JSX } from 'react'
 import {
   Lookup,
   ObjectFromUnion,

--- a/packages/shared/src/hooks/useMemoOne.ts
+++ b/packages/shared/src/hooks/useMemoOne.ts
@@ -14,7 +14,7 @@ export function useMemoOne<T>(getResult: () => T, inputs?: any[]): T {
     })
   )
 
-  const committed = useRef<Cache<T>>(null)
+  const committed = useRef<Cache<T> | null>(null)
   const prevCache = committed.current
 
   let cache = prevCache

--- a/targets/three/src/animated.ts
+++ b/targets/three/src/animated.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { CSSProperties, ForwardRefExoticComponent, FC } from 'react'
+import { CSSProperties, ForwardRefExoticComponent, FC, JSX } from 'react'
 import {
   AssignableKeys,
   ComponentPropsWithRef,

--- a/targets/three/src/index.ts
+++ b/targets/three/src/index.ts
@@ -19,7 +19,10 @@ addEffect(() => {
 })
 
 const host = createHost(primitives, {
-  applyAnimatedValues: applyProps,
+  applyAnimatedValues: (instance, props) => {
+    applyProps(instance, props)
+    return
+  },
 })
 
 export const animated = host.animated as WithAnimated

--- a/targets/three/src/primitives.ts
+++ b/targets/three/src/primitives.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 import '@react-three/fiber'
+import { JSX } from 'react'
 
 export type Primitives = keyof JSX.IntrinsicElements
 

--- a/targets/web/src/primitives.ts
+++ b/targets/web/src/primitives.ts
@@ -1,3 +1,5 @@
+import { JSX } from 'react'
+
 export type Primitives = keyof JSX.IntrinsicElements
 export const primitives: Primitives[] = [
   'a',


### PR DESCRIPTION
### Why
JSX moved from the global namespace to the React module. Use of global breaks internal type declarations. 

Resolves [#2358](https://github.com/pmndrs/react-spring/issues/2358) and ensures compatibility with React 19.

### What

- Explicitly import JSX type from 'react' in JSX-related types (web, shared, three)
- Fixes type-level issues with WithAnimated and component declarations
- Fix useRef type errors on build
- Backwards-compatible with React 18

### Checklist

- [ ] Documentation updated (Not applicable)
- [ ] Demo added (Not applicable)
- [X] Ready to be merged

